### PR TITLE
add fastapi standard cli tools for "fastapi dev ..."

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ packages = [{include = "openfoundry"}]
 
 [tool.poetry.dependencies]
 python = "^3.12"
-fastapi = "^0.115.14"
+fastapi = {extras = ["standard"], version = "^0.115.14"}
 uvicorn = "^0.35.0"
 sqlalchemy = "^2.0.41"
 alembic = "^1.16.2"


### PR DESCRIPTION
I like to use `fastapi dev ...` command line tool, just adding the "standard" extras brings these shell commands in