### PR TITLE
add ggshield as secret precommit scanning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -271,5 +271,6 @@ tmp/
 temp/
 .tmp/
 .temp/
+.cache_ggshield
 
 storage/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,6 +48,16 @@ repos:
         pass_filenames: false
         files: ^openfoundry/.*\.py$
 
+  - repo: https://github.com/GitGuardian/ggshield
+    rev: v1.41.0
+    hooks:
+      - id: ggshield
+        name: GitGuardian Shield Secret Scan
+        entry: ggshield secret scan pre-commit
+        language: system
+        always_run: true
+        pass_filenames: false
+
   - repo: local
     hooks:
       - id: frontend-lint

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ SANDBOX_DOCKER_FILE := sandbox/Dockerfile
 docker-images:
 	@echo "Building Docker image: $(IMAGE_NAME)"
 	docker build -f $(DOCKER_FILE) -t $(IMAGE_NAME) .
-
+echo "AKIAIOSFODNN7EXAMPLE"
 # Build the sandbox Docker image
 docker-sandbox-images:
 	@echo "Building sandbox Docker image: $(SANDBOX_IMAGE_NAME)"
@@ -36,6 +36,17 @@ install-frontend:
 # Setup pre-commit hooks
 setup-precommit:
 	@echo "Setting up pre-commit hooks..."
+	@echo "Checking if ggshield is installed..."
+	@if ! command -v ggshield >/dev/null 2>&1; then \
+		echo "❌ ggshield is not installed. Please install it first:"; \
+		echo "   Visit: https://github.com/GitGuardian/ggshield"; \
+		echo "   Or install on Linux:"; \
+		echo "     wget https://github.com/GitGuardian/ggshield/releases/download/v1.41.0/ggshield_1.41.0-1_amd64.deb"; \
+		echo "     sudo dpkg -i ggshield_1.41.0-1_amd64.deb"; \
+		echo "   Or install on macOS:"; \
+		echo "     brew install ggshield"; \
+		exit 1; \
+	fi
 	poetry run pre-commit install
 	@echo "Pre-commit hooks installed successfully!"
 


### PR DESCRIPTION
Steps to set up local ggshield scanning:
1. Sign up to https://www.gitguardian.com/ggshield, just so that you have a free account
2. Install ggshield (on mac with brew, or on linux with the deb package from https://github.com/GitGuardian/ggshield/releases/tag/v1.41.0)
3. run `ggshield auth login`
4. run `make setup-precommit`


From then on, every commit will be checked for API key patterns. I tested with our OpenAI key and it was able to flag it.