### PR TITLE
add upload_secrets_to_sandbox endpoint

### DIFF
--- a/openfoundry/models/agent_sessions/docker_utils.py
+++ b/openfoundry/models/agent_sessions/docker_utils.py
@@ -4,14 +4,14 @@ import tarfile
 import tempfile
 from functools import cache
 from pathlib import Path
-from typing import NamedTuple
 
 import docker
+from pydantic import BaseModel
 
 from openfoundry.logger import logger
 
 
-class SecretPayload(NamedTuple):
+class SecretPayload(BaseModel):
     name: str
     secrets: dict[str, str]
     prefix: str | None = None

--- a/sandbox/openfoundry_sandbox/connection_manager.py
+++ b/sandbox/openfoundry_sandbox/connection_manager.py
@@ -45,6 +45,23 @@ class ConnectionManager:
         """List all available connection names."""
         return list(self._connections.keys())
 
+    def add_connection(self, secrets_dir: Path, connection_name: str) -> None:
+        """Add a new connection from a secrets directory.
+
+        Args:
+            secrets_dir: Path to the directory containing connection secrets
+            connection_name: Name of the connection
+
+        Raises:
+            ValueError: If connection cannot be created or added
+        """
+        connection = self._create_connection(connection_name, secrets_dir)
+        if not connection:
+            raise ValueError(f"Failed to create connection '{connection_name}'")
+
+        self._connections[connection_name] = connection
+        logger.info(f"Successfully added connection: {connection_name}")
+
     def initialize_connections(self) -> None:
         """Initialize all connections from the connections directory."""
         logger.info(f"Initializing connections from {CONNECTIONS_DIR}")


### PR DESCRIPTION
the `upload_secrets_to_sandbox` endpoint does the following:

- extract the secret payload based on the secret_type. Currently, it is only CONNECTIONS
- call the PUT /secrets/ endpoint in the sandbox server
- update the PUT /secrets/ endpoint to call the connection manager to add the new connection

before adding the connection:
![image](https://github.com/user-attachments/assets/d2125d86-af99-45c4-b2e9-a5e3b86dfbb3)


after calling `upload_secrets_to_sandbox`:
![image](https://github.com/user-attachments/assets/31cfeb39-6fa0-4209-95fb-466baa477081)
![image](https://github.com/user-attachments/assets/c7b594c6-07b8-407f-a749-bf3b252c987e)
