### PR TITLE
fix hr and fix strong styling bugs

### DIFF
--- a/frontend/src/components/chat/MarkdownMessage.tsx
+++ b/frontend/src/components/chat/MarkdownMessage.tsx
@@ -64,9 +64,7 @@ export const MarkdownMessage: React.FC<MarkdownMessageProps> = ({
         components={{
           // Customize heading styles
           strong: ({ children }) => (
-            <h3 className="text-md font-semibold mt-2 text-gray-900">
-              {children}
-            </h3>
+            <strong className="font-semibold text-gray-900">{children}</strong>
           ),
           h1: ({ children }) => (
             <h1 className="text-xl font-bold mb-3 text-gray-900">{children}</h1>
@@ -159,6 +157,8 @@ export const MarkdownMessage: React.FC<MarkdownMessageProps> = ({
               {children}
             </a>
           ),
+          // Customize horizontal rule styles
+          hr: () => <hr className="my-6 border-t border-gray-300" />,
         }}
       >
         {content}


### PR DESCRIPTION
1. fix hydration error where `<h3> cannot be a descendant of <p>.`, the h3 was for a strong, but its inside a div, so it causes html errors in console
2. the `<hr>` was not being rendered with nice spacing

<img width="713" height="275" alt="image" src="https://github.com/user-attachments/assets/298cf5ff-159c-437e-b3ed-cce528a11f35" />
